### PR TITLE
Fast clear when both the key and value type are trivially destructible

### DIFF
--- a/flat_hash_map.hpp
+++ b/flat_hash_map.hpp
@@ -721,7 +721,7 @@ public:
 
     void clear()
     {
-        if (std::is_trivially_destructible_v<FindKey> && std::is_trivially_destructible_v<value_type>)
+        if constexpr (std::is_trivially_destructible_v<FindKey> && std::is_trivially_destructible_v<value_type>)
         {
             reset_to_empty_state(false);
         }


### PR DESCRIPTION
I have a map with 16 million entries and calling clear() takes around 50 to 100 milliseconds.

The clear() function destroys every entry in a for loop. But if both the key and value types are 'is_trivially_destructible', (for example map<int, int>) then it does not have to call the destructor on every key/value.

This reduces the time spent in clear() to less than 1 microsecond.