### PR TITLE
Two small additions to flat_hash_map

### DIFF
--- a/flat_hash_map.hpp
+++ b/flat_hash_map.hpp
@@ -428,7 +428,9 @@ public:
     }
     ~sherwood_v3_table()
     {
-        clear();
+        if constexpr (not std::is_trivially_destructible_v<value_type>) {
+          clear();
+        }
         deallocate_data(entries, num_slots_minus_one, max_lookups);
     }
 
@@ -554,6 +556,10 @@ public:
     size_t count(const FindKey & key) const
     {
         return find(key) == end() ? 0 : 1;
+    }
+    bool contains(const FindKey & key) const
+    {
+        return find(key) != end();
     }
     std::pair<iterator, iterator> equal_range(const FindKey & key)
     {


### PR DESCRIPTION
I recently encountered a problem in using flat_hash_map with really large data. I was surprised that the destructor was taking almost half a second to run. I realized it's because we were iterating over the entire table to destruct the entries, even though the entries were trivially destructible. This change will skip that last clear() call in the event that the destructors need not be run.

Secondly I added the contains() method since it was added to std::unordered_map<> with C++20.
